### PR TITLE
Bug fix:  Allow empty multi instance resources

### DIFF
--- a/mbed-client/source/m2mnsdlinterface.cpp
+++ b/mbed-client/source/m2mnsdlinterface.cpp
@@ -1648,7 +1648,9 @@ bool M2MNsdlInterface::create_nsdl_resource_structure(M2MResource *res,
                     }
                 }
                 // Register the main Resource as well along with ResourceInstances
-                success = create_nsdl_resource(res);
+                success = create_nsdl_resource(res);                
+            } else {
+                success = create_nsdl_resource(res); //this is also legal, an empty multi instance resource that the server can later PUT instances into
             }
         } else {
             success = create_nsdl_resource(res);

--- a/mbed-client/source/m2mtlvdeserializer.cpp
+++ b/mbed-client/source/m2mtlvdeserializer.cpp
@@ -345,10 +345,12 @@ M2MTLVDeserializer::Error M2MTLVDeserializer::deserialize_resource_instances(con
             }
         }
         if(!found) {
-            if(M2MTLVDeserializer::Post == operation) {
-                error = M2MTLVDeserializer::NotAllowed;
-            } else if(M2MTLVDeserializer::Put == operation) {
-                error = M2MTLVDeserializer::NotFound;
+            M2MResourceInstance *res_instance = resource.get_parent_object_instance().create_dynamic_resource_instance(resource.name(),"",
+                                                                                            resource.resource_instance_type(),
+                                                                                            true,
+                                                                                            til._id);
+            if(res_instance) {
+                res_instance->set_operation(M2MBase::GET_PUT_POST_DELETE_ALLOWED);
             }
         }
     } else {


### PR DESCRIPTION
The client fails to register currently if a multi instance resource is created without any instances.  This is allowed by the spec, in fact, it makes sense.  The client may want to create a multi instance resource with no initial instances so that the server can PUT the resource instances later.  (For example, our use case is just a simple place for our web team to store information specific to the IoT node in STRING format)

<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[x] I confirm this contribution is my own and I agree to license it with Apache 2.0.
[x] I confirm the moderators may change the PR before merging it in.
[x] I understand the release model prohibits detailed Git history and my contribution will be recorded to the list at the bottom of [CONTRIBUTING.md](CONTRIBUTING.md).


### Summary of changes <!-- Required -->

<!--
    Please provide the following information:

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed, add references to issues if this is a fix.

    Avoid too large commits. Each commit should be an atomic, independent change.

    Write good, descriptive Git commit messages.

-->

