### PR TITLE
Fix compile error for Mbed TF-M V8M target

### DIFF
--- a/factory-configurator-client/psa-driver/source/psa_driver_crypto.c
+++ b/factory-configurator-client/psa-driver/source/psa_driver_crypto.c
@@ -14,6 +14,7 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------
 #ifdef MBED_CONF_MBED_CLOUD_CLIENT_PSA_SUPPORT
+#include "platform/mbed_version.h"
 #include "psa_driver.h"
 #include "psa/protected_storage.h"
 #include "psa/crypto.h"

--- a/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/mbedOS/Update/pal_plat_update.cpp
+++ b/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/mbedOS/Update/pal_plat_update.cpp
@@ -60,6 +60,7 @@ palStatus_t pal_plat_imageActivate(palImageId_t imageId)
 
 palStatus_t pal_plat_imageGetActiveHash(palBuffer_t *hash)
 {
+#if DEVICE_FLASH
     palStatus_t ret = PAL_ERR_UPDATE_ERROR;
     uint32_t read_offset = PAL_UPDATE_ACTIVE_METADATA_HEADER_OFFSET +
                             offsetof(FirmwareHeader_t, firmwareSHA256);
@@ -95,6 +96,9 @@ palStatus_t pal_plat_imageGetActiveHash(palBuffer_t *hash)
 
 exit:
     return ret;
+#else
+    return PAL_ERR_NOT_IMPLEMENTED;
+#endif
 }
 
 palStatus_t pal_plat_imageGetActiveVersion (palBuffer_t* version)


### PR DESCRIPTION
<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[x] I confirm this contribution is my own and I agree to license it with Apache 2.0.
[x] I confirm the moderators may change the PR before merging it in.
[x] I understand the release model prohibits detailed Git history and my contribution will be recorded to the list at the bottom of [CONTRIBUTING.md](CONTRIBUTING.md).


### Summary of changes <!-- Required -->

This PR tries to fix compile error for Mbed TF-M V8M target, usually without `FLASHIAP`:
1. Use `DEVICE_FLASH` to exclude `FLASHIAP` code
1. Fix `MBED_MAJOR_VERSION` isn't available, which is needed to exclude `mbedtls_psa_crypto_free()`.

